### PR TITLE
サイドバーのcollapsedをfalseに

### DIFF
--- a/docs/.vitepress/sidebarConfigs/chapters/chapter1/chapter1.ts
+++ b/docs/.vitepress/sidebarConfigs/chapters/chapter1/chapter1.ts
@@ -13,7 +13,7 @@ export const chapter1SidebarItems: DefaultTheme.SidebarItem[] = [
       ...dictSidebarItems,
       {
         text: '実習編',
-        collapsed: true,
+        collapsed: false,
         items: [
           ...section1SidebarItems,
           ...section2SidebarItems,


### PR DESCRIPTION
プロパティ自体を消すと手動でcollapseできなくなる(▽ボタン自体表示されなくなる)ので、一応残しておきました