### PR TITLE
light themeのコードブロックの見た目をdark themeに寄せた

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   head: [['link', { rel: 'icon', href: '/naro-text/favicon.ico' }]],
   markdown: {
     theme: {
-      light: 'github-light',
+      light: 'github-dark',
       dark: 'github-dark'
     }
   },

--- a/docs/.vitepress/theme/trap.css
+++ b/docs/.vitepress/theme/trap.css
@@ -282,7 +282,7 @@
   --vp-c-code-dimm: var(--vp-c-text-2);
 
   --vp-code-block-color: var(--vp-c-text-1);
-  --vp-code-block-bg: #f8f8f8;
+  --vp-code-block-bg: #161618;
   --vp-code-block-divider-color: var(--vp-c-divider);
 
   --vp-code-line-highlight-color: #ececec;

--- a/docs/.vitepress/theme/trap.css
+++ b/docs/.vitepress/theme/trap.css
@@ -288,9 +288,9 @@
   --vp-code-line-highlight-color: #ececec;
   --vp-code-line-number-color: var(--vp-c-code-dimm);
 
-  --vp-code-copy-code-bg: #e2e2e2;
-  --vp-code-copy-code-hover-bg: #dcdcdc;
-  --vp-code-copy-code-active-text: var(--vp-c-text-2);
+  --vp-code-copy-code-bg: var(--vp-code-block-bg-light);
+  --vp-code-copy-code-hover-border-color: var(--vp-c-divider);
+  --vp-code-copy-code-hover-bg: var(--vp-code-block-bg-light);
 
   --vp-code-tab-divider: var(--vp-c-divider);
   --vp-code-tab-text-color: var(--vp-c-text-2);


### PR DESCRIPTION
close #60 

light themeで使う色にしては背景色が黒すぎるかもしれない？
![image](https://github.com/traPtitech/naro-text/assets/50443000/49192997-701a-48a3-86d8-305e62998ab2)
