### PR TITLE
light themeでのコードブロックタブをdark themeと同じにした

### DIFF
--- a/docs/.vitepress/theme/trap.css
+++ b/docs/.vitepress/theme/trap.css
@@ -292,11 +292,12 @@
   --vp-code-copy-code-hover-border-color: var(--vp-c-divider);
   --vp-code-copy-code-hover-bg: var(--vp-code-block-bg-light);
 
-  --vp-code-tab-divider: var(--vp-c-divider);
-  --vp-code-tab-text-color: var(--vp-c-text-2);
+  --vp-code-tab-divider: var(--vp-code-block-divider-color);
+  --vp-code-tab-text-color: var(--vp-c-text-dark-2);
   --vp-code-tab-bg: var(--vp-code-block-bg);
-  --vp-code-tab-hover-text-color: var(--vp-c-text-1);
-  --vp-code-tab-active-text-color: var(--vp-c-text-1);
+  --vp-code-tab-hover-text-color: var(--vp-c-text-dark-1);
+  --vp-code-tab-active-text-color: var(--vp-c-text-dark-1);
+  --vp-code-tab-active-text-color: var(--vp-c-text-dark-1);
 }
 
 /**


### PR DESCRIPTION
ref: https://github.com/traPtitech/naro-text/pull/82#pullrequestreview-1520547658

![image](https://github.com/traPtitech/naro-text/assets/50443000/51ff58d4-7b33-4c86-a947-d00aae0d3448)
