### PR TITLE
light themeでのコードブロックのhighlight時背景色を変更

### DIFF
--- a/docs/.vitepress/theme/trap.css
+++ b/docs/.vitepress/theme/trap.css
@@ -285,7 +285,7 @@
   --vp-code-block-bg: #161618;
   --vp-code-block-divider-color: var(--vp-c-divider);
 
-  --vp-code-line-highlight-color: #ececec;
+  --vp-code-line-highlight-color: rgba(0, 0, 0, 0.5);
   --vp-code-line-number-color: var(--vp-c-code-dimm);
 
   --vp-code-copy-code-bg: var(--vp-code-block-bg-light);

--- a/docs/.vitepress/theme/trap.css
+++ b/docs/.vitepress/theme/trap.css
@@ -248,7 +248,7 @@
   --vp-code-block-bg-light: #1e1e20;
   --vp-code-block-divider-color: #000000;
 
-  --vp-code-line-highlight-color: rgba(0, 0, 0, 0.5);
+  --vp-code-line-highlight-color: rgba(255, 255, 0, 0.15);
   --vp-code-line-number-color: var(--vp-c-code-dimm);
 
   --vp-code-line-diff-add-color: var(--vp-c-green-dimm-2);
@@ -285,7 +285,7 @@
   --vp-code-block-bg: #161618;
   --vp-code-block-divider-color: var(--vp-c-divider);
 
-  --vp-code-line-highlight-color: rgba(0, 0, 0, 0.5);
+  --vp-code-line-highlight-color: rgba(255, 255, 0, 0.15);
   --vp-code-line-number-color: var(--vp-c-code-dimm);
 
   --vp-code-copy-code-bg: var(--vp-code-block-bg-light);


### PR DESCRIPTION
close #118 

#82 による影響範囲の考慮漏れが原因
同様に、dark themeでのhighlightedと同じ色に変更した

![image](https://github.com/traPtitech/naro-text/assets/50443000/784a5ef0-c32f-4fda-b534-db41c45cad96)
