### PR TITLE
デプロイ用設定ファイル例のリンクが間違っている問題を修正

### DIFF
--- a/docs/chapter1/section2/2_publish.md
+++ b/docs/chapter1/section2/2_publish.md
@@ -71,7 +71,7 @@ GitHub Pages で公開された URL は GitHub Actions の実行が終わり次�
 ![](images/2/site-url.png)
 
 今回の設定ファイルを入れたものは以下のブランチに入っています。参考にしてみてください。  
-[traPtitech/naro-template-frontend at example/todolist](https://github.com/traPtitech/naro-template-frontend/tree/example/todolist)
+[traPtitech/naro-template-frontend at example/deploy](https://github.com/traPtitech/naro-template-frontend/tree/example/deploy)
 
 ### まとめ
 お疲れさまでした！  


### PR DESCRIPTION
GithubActionsで公開するところの例を示すブランチのURLが間違っていたようなので修正しました。確認お願いします:pray: