### PR TITLE
textlint拡張機能を現行のものに置き換え

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["taichi.vscode-textlint"]
+  "recommendations": ["3w36zj6.textlint"]
 }


### PR DESCRIPTION
taichi.vscode-textlintは個人プロジェクトでメンテナンスが止まっており、現在は3w36zj6.textlintに移行してコミュニティベースで開発されているらしい
ref: https://github.com/orgs/textlint/discussions/2