### PR TITLE
`code`のフォントにフォールバックとしてNoto Sans JPを追加

### DIFF
--- a/slides/style.css
+++ b/slides/style.css
@@ -76,7 +76,7 @@ a {
 }
 
 code {
-  font-family: 'Noto Sans Mono', monospace;
+  font-family: 'Noto Sans Mono', 'Noto Sans JP', monospace;
 }
 
 /* タイトルスライド */


### PR DESCRIPTION
#171 でNoto Sans Monoを当てるようになったが、Noto Sans Monoは日本語を含まないため。
環境に依存しないという点でNoto Sans Monoを使うメリットはあるのでそれは残したまま、Noto Sans JPを追加した（日本語部分は等幅なので多分問題ないと思う）