### PR TITLE
readme: スライドのデプロイ先について説明を補足

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ https://vitepress.dev/guide/markdown
 - `{index}_{name}.md`
   - 例: `0_index.md`
 - 画像
-  - `images`ディレクトリを切って配置 
-  - 画像の名前で何の画像かわかるようにしてください 
+  - `images`ディレクトリを切って配置
+  - 画像の名前で何の画像かわかるようにしてください
 
 ## 記入の注意点
 - 内輪ネタは避けましょう
@@ -32,6 +32,10 @@ https://vitepress.dev/guide/markdown
 | バックエンド   | 8080       |
 | Adminer        | 8081       |
 
-## workflow - slides.ymlについて
-- スライドのビルドとアップロードを行う GitHub Actions のワークフローです。
-- リリース時に自動で実行され、スライドが該当するReleaseのAssetsにアップロードされます。
+## workflow - pages.yamlについて
+`main` ブランチに push されると、GitHub Actions (`pages.yaml`) が実行され、ドキュメント（VitePress）とスライド（Marp）が GitHub Pages に自動デプロイされます
+
+※ `lecture1` の部分を適宜、`lecture2`, `lecture3` などの回に応じたファイル名に置き換えてアクセスしてください
+
+- **HTML**: `https://traptitech.github.io/naro-text/slides/lecture1.html`
+- **PDF**: `https://traptitech.github.io/naro-text/slides/lecture1.pdf`


### PR DESCRIPTION
- .github/workflow/slides.yaml についての記述を加えた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント
* アセット管理のガイドラインを明確化しました。
* GitHub Pages への自動デプロイメント手順を更新し、ドキュメントとスライド資料の公開方法を説明しました。
* 各講義資料へのアクセス方法（HTML 形式・PDF 形式）を整備しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->