### PR TITLE
座学スライドへの導線を追加

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,7 +27,10 @@ export default defineConfig({
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     siteTitle: 'なろう講習会',
-    nav: [{ text: 'Home', link: '/' }],
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: '座学編', link: '/lectures/' }
+    ],
 
     sidebar: {
       '/web_basic/': buildSidebar('web_basic'),

--- a/docs/.vitepress/sidebarConfigs/buildSidebar.ts
+++ b/docs/.vitepress/sidebarConfigs/buildSidebar.ts
@@ -25,6 +25,7 @@ const chapterOrder: ChapterKey[] = ['web_basic', 'chapter1', 'chapter2', 'chapte
 export function buildSidebar(current: ChapterKey): DefaultTheme.SidebarItem[] {
   return [
     { text: 'トップページ', link: '/' },
+    { text: '座学編（スライド）', link: '/lectures/' },
     ...chapterOrder.flatMap((chapter) =>
       chapter === current ? chapterFullItems[chapter] : [chapterLinks[chapter]]
     )

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme'
 import './trap.css'
+import './lectures.css'
 
 export default DefaultTheme

--- a/docs/.vitepress/theme/lectures.css
+++ b/docs/.vitepress/theme/lectures.css
@@ -1,0 +1,124 @@
+/**
+ * 座学編のスライド一覧
+ * -------------------------------------------------------------------------- */
+.lecture-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 24px 0;
+}
+
+.lecture-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+.lecture-card:hover {
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.lecture-card__number {
+  margin: 0 0 8px;
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.lecture-card h3 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 18px;
+  line-height: 1.5;
+}
+
+.lecture-card > p:not(.lecture-card__number) {
+  flex: 1;
+  margin: 12px 0 20px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1.8;
+}
+
+.lecture-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lecture-card__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none !important;
+  transition:
+    color 0.2s,
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.lecture-card__button--primary {
+  color: var(--vp-button-brand-text) !important;
+  background-color: var(--vp-button-brand-bg);
+}
+
+.lecture-card__button--primary:hover {
+  background-color: var(--vp-button-brand-hover-bg);
+}
+
+.lecture-card__button--secondary {
+  border-color: var(--vp-c-divider);
+  color: var(--vp-c-text-1) !important;
+  background-color: var(--vp-c-bg);
+}
+
+.lecture-card__button--secondary:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1) !important;
+}
+
+.lecture-card__button:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .lecture-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lecture-card {
+    padding: 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lecture-card,
+  .lecture-card__button {
+    transition: none;
+  }
+
+  .lecture-card:hover {
+    transform: none;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,13 @@ layout: home
 hero:
   name: "Webエンジニアになろう講習会"
   tagline: traP SysAd班
+  actions:
+    - theme: brand
+      text: 座学編を見る
+      link: /lectures/
+    - theme: alt
+      text: 実習編を読む
+      link: /chapter1/
 features:
   - title: Web開発の基礎
     details: Web開発の基礎的な知識を学びます。
@@ -21,4 +28,3 @@ features:
     details: インターネットがどのように動いているかを学びます。
     link: /chapter4/0_index.md
 ---
-

--- a/docs/lectures/index.md
+++ b/docs/lectures/index.md
@@ -1,0 +1,111 @@
+---
+title: 座学編
+description: Webエンジニアになろう講習会の座学スライド一覧
+outline: [2, 2]
+---
+
+# 座学編
+
+Webエンジニアになろう講習会の座学スライドです。
+座学編で技術の全体像や背景をつかんだ後、対応する実習編で実際に手を動かして学びます。
+
+::: tip 資料の見方
+レイアウトされたスライドをそのまま読める**PDF 版がおすすめ**です。
+ブラウザ上でスライドをめくりたい場合は HTML 版を利用できます。どちらも新しいタブで開きます。
+:::
+
+## 第一部
+
+Web サービスの基本要素を知り、基本的な Web アプリを作るための知識を学びます。
+
+<div class="lecture-grid">
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 1</p>
+    <h3>オリエンテーション＆Webアプリ概論</h3>
+    <p>講習会の進め方と、traQ を題材にフロントエンド、ネットワーク、サーバー、データベースが連携する Web アプリの全体像を学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture1.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture1.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 2</p>
+    <h3>プログラミング心得＆フロントエンド基礎</h3>
+    <p>読みやすいコード、Linter・Formatter、コードレビューを起点に、JavaScript の歴史と現代の Web フロントエンド開発を学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture2.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture2.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 3</p>
+    <h3>インターネット概論＆サーバー入門</h3>
+    <p>HTTP のリクエスト・レスポンスから、TCP の順序制御と到達保証、IP によるデータ伝送までを学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture3.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture3.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 4</p>
+    <h3>データベース入門</h3>
+    <p>RDBMS・SQL・NoSQL などのデータベース基礎と、設定値や機密情報を安全に扱うための環境変数を学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture4.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture4.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+</div>
+
+[第一部の実習編へ](/chapter1/)
+
+## 第二部
+
+認証・認可、セキュリティ、テスト、コンテナなど、Web アプリを安全に開発・運用するための周辺技術を学びます。
+
+<div class="lecture-grid">
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 5</p>
+    <h3>認証・認可</h3>
+    <p>認証と認可の違い、パスワード、セッション、JWT、OAuth 2.0、OpenID Connect の仕組みを学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture5.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture5.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 6</p>
+    <h3>セキュリティ入門</h3>
+    <p>サーバーとブラウザの両面から、SQL Injection、SOP・CORS、XSS、CSP、Cookie などのセキュリティを学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture6.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture6.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 7</p>
+    <h3>テスト・CI/CD</h3>
+    <p>テストの役割と種類、Mocking、GitHub Actions を使った CI/CD の考え方を学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture7.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture7.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+
+  <article class="lecture-card">
+    <p class="lecture-card__number">LECTURE 8</p>
+    <h3>Docker</h3>
+    <p>Docker とコンテナの仕組み、Image、Volume、Network など、実践に必要な基礎を学びます。</p>
+    <div class="lecture-card__actions">
+      <a class="lecture-card__button lecture-card__button--primary" href="../slides/lecture8.pdf" target="_blank" rel="noopener noreferrer">PDF で見る<span aria-hidden="true">↗</span></a>
+      <a class="lecture-card__button lecture-card__button--secondary" href="../slides/lecture8.html" target="_blank" rel="noopener noreferrer">HTML で見る<span aria-hidden="true">↗</span></a>
+    </div>
+  </article>
+</div>
+
+[第二部の実習編へ](/chapter2/)


### PR DESCRIPTION
## 概要

- トップページに「座学編を見る」「実習編を読む」の導線を追加しました
- 第一部・第二部に分けた座学スライド一覧ページを追加しました
  - 各資料の内容を要約して掲載
  - PDF 版を主導線、HTML 版を補助導線として掲載
  - 第一部・第二部それぞれの実習編へのリンクを掲載
- グローバルナビと各実習ページのサイドバーから座学編へ移動できるようにしました
- スライド一覧をライト・ダークテーマとモバイル表示に対応させました

## 背景

座学スライドは GitHub Pages に PDF / HTML としてデプロイされていましたが、テキスト本体からリンクされておらず、URL を知っている人しかアクセスできない状態でした。

座学で背景知識をつかんでから実習へ進む講習会の構成が伝わるよう、トップページ・共通ナビ・実習編サイドバーから到達できる一覧ページを用意しています。

## 確認

- `vitepress build docs`
- Prettier（変更ファイル）
- textlint（`docs/index.md`、`docs/lectures/index.md`）
- Playwright
  - トップページの 2 導線
  - 8 カード / 16 スライドリンク
  - グローバルナビ / 実習編サイドバー
  - デスクトップ 2 列 / モバイル 1 列
  - ライト / ダークテーマ
  - 横スクロール、ブラウザコンソールエラーがないこと
- 公開済みの PDF 8 本 / HTML 8 本がすべて HTTP 200 を返すこと


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「座学編」ページを追加し、LECTURE 1〜8の一覧を確認できるようになりました。
  * 各講義のPDF版・HTML版を閲覧できるリンクを追加しました。
  * 座学編と実習編へ移動する導線をトップページに追加しました。
  * ナビゲーションメニューから座学編へアクセスできるようになりました。

* **スタイル**
  * 講義一覧をカード形式で表示し、画面幅に応じたレイアウトに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->